### PR TITLE
ISSUE_TEMPLATE/bug_report.yml: add "needs review" label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report a problem in existing functionality, including documentation and infrastructure.
-labels: ["bug"]
+labels: ["bug", "needs review"]
 
 body:
   - type: markdown


### PR DESCRIPTION
The goal is that this label gets assigned automatically when user creates a bug report. After problem classification / resposne, this label can be removed / replaced. We can then easily filter which reports have not received proper actions to classify the problem by the Dasharo team.