### PR TITLE
bug_report.yml: change types of summary and reproductibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -95,7 +95,7 @@ body:
     validations:
       required: false
 
-  - type: input
+  - type: textarea
     id: summary
     attributes:
       label: Brief summary
@@ -103,7 +103,7 @@ body:
     validations:
       required: true
 
-  - type: textarea
+  - type: input
     id: reproductibility
     attributes:
       label: How reproducible


### PR DESCRIPTION
These seemed to be swapped, long description had one line entry type, while simple percentage had whole text area.